### PR TITLE
Refactor decode to use parseUri

### DIFF
--- a/extension/myScript.js
+++ b/extension/myScript.js
@@ -25,7 +25,7 @@ function httpGet(input, type, data) {
 	var page = (type=="url")? decode(input) : input;
 	var theUrl = server + contents + page;
 	theUrl = theUrl.replace("&", "^");
-	
+
 	//console.log("Type: " + type + " : " + page);
 
 	fetch(theUrl)
@@ -42,7 +42,7 @@ function httpGet(input, type, data) {
 			}
 			data.appendChild(btn);
 		});
-	
+
 }
 
 /**
@@ -76,22 +76,46 @@ function hoverTooltip(info) {
  * Parse through Facebook's encoded url for the actual url
  *
  */
+function parseUri(str) {
+  var o = parseUri.options,
+    m = o.parser[o.strictMode ? "strict" : "loose"].exec(str),
+    uri = {},
+    i = 14;
+
+  while (i--) uri[o.key[i]] = m[i] || "";
+
+  uri[o.q.name] = {};
+  uri[o.key[12]].replace(o.q.parser, function($0, $1, $2) {
+    if ($1) uri[o.q.name][$1] = $2;
+  });
+
+  return uri;
+};
+
+parseUri.options = {
+  strictMode: false,
+  key: ["source", "protocol", "authority", "userInfo", "user", "password", "host", "port", "relative", "path", "directory", "file", "query", "anchor"],
+  q: {
+    name: "queryKey",
+    parser: /(?:^|&)([^&=]*)=?([^&]*)/g
+  },
+  parser: {
+    strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+    loose: /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
+  }
+};
+
 function decode(code) {
+ var url_obj = parseUri(code);
 
-	var res = "" + code;
-	res = res
-		.replace("http://l.facebook.com/l.php?u=", "")
-		.replace(/%3A/gi, ":")
-		.replace(/%F/gi, "/")
-		.replace(/%2F/gi, "/");
-
-	var end = res.substr(res.indexOf("^h"), res.length);
-	res = res.replace(end, "");
-	var end2 = res.substr(res.indexOf("&"), res.length);
-	res = res.replace(end2, "");
-
-	return res;
-}  
+ if (url_obj.queryKey.u) {
+   return url_obj.queryKey.u;
+ } else if (url_obj.host === 'www.facebook.com') {
+   return url_obj;
+ } else {
+   return link;
+ }
+}
 
 /**
  * Receive each Facebook post and analyze texts, urls, pics for validity.
@@ -99,7 +123,7 @@ function decode(code) {
  *
  */
 setInterval(function() {
-	
+
 	var test = document.getElementsByClassName('_4-u2 mbm _5v3q _4-u8');
 
 	for(var i=0; i<test.length; i++) {
@@ -123,13 +147,13 @@ setInterval(function() {
 				httpGet(linked.querySelector('a').href, "url", data);
 			}
 
-	
+
 			var link = test[i].querySelector('._5pbx.userContent');
 			if(!processed && link != null && link.querySelector('a') != null && link.querySelector('a').href != null) {
 				processed = true;
 				httpGet(link.href, "url", data);
 			}
-            
+
 
 			var picComment = test[i].querySelector('.uiScaledImageContainer._4-ep');
 			if(!processed && picComment != null && picComment.querySelector('img') != undefined && picComment.querySelector('img').src != null) {
@@ -142,7 +166,7 @@ setInterval(function() {
 				processed = true;
 				httpGet(picPost.querySelector('img').src, "image", data);
 			}
-			
+
 			var picTagged = test[i].querySelector('._4-eo._2t9n');
 			if(!processed && picTagged != null && picTagged.querySelector('._46-h._4-ep') != null && picTagged.querySelector('._46-h._4-ep').querySelector('img') != null) {
 				processed = true;
@@ -163,10 +187,10 @@ setInterval(function() {
 				processed = true;
 				httpGet(text.textContent, "text", data);
 			}
-	
+
 		}
 	}
 
 }, 1000);
-	
+
 })(document);


### PR DESCRIPTION
In myScript, decode can be rewritten to use Steven Levithan’s parseUri code in order to better decipher external links and distinguish them from Facebook-native links. Using parseUri, an external link can be isolated via the ‘u’ parameter in a query string. And since some of the links identified by myScript are Facebook-native links like hashtags or links to people’s profiles or Pages, parseUri can be used to identify these native links, in case the server could be refactored to handle these links in a particular way.